### PR TITLE
Don't use numexpr version 2.8.4

### DIFF
--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -105,7 +105,7 @@ dependencies:
   - nodejs
   - nsls2-detector-handlers >=0.0.3
   - nslsii >=0.10.7
-  - numexpr >=2.8.0
+  - numexpr >=2.8.0,!=2.8.4
   - numpy >=1.20
   - nyxtools >=0.0.12
   - oct2py


### PR DESCRIPTION
Version 2.8.4 of `numexpr` was giving me an import error when reading tiled data in the `2025-1.0-py312-tiled` env:
```py
ImportError: /lib64/libc.so.6: version `GLIBC_2.38' not found (required by /nsls2/conda/envs/2025-1.0-py312-tiled/lib/python3.12/site-packages/numexpr/interpreter.cpython-312-x86_64-linux-gnu.so)
```

I tested with some other versions of numexpr and didn't hit the error, so I think it was an issue with this version.