### PR TITLE
Add `CONDA_OVERRIDE_GLIBC` env var

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,6 +97,8 @@ jobs:
         with:
           environment-file: envs/env-py${{ env.PYTHONVER }}.yml
           log-level: info
+        env:
+          CONDA_OVERRIDE_GLIBC: "2.28"
 
       # # For testing only:
       # - name: Setup umamba


### PR DESCRIPTION
This will match the glibc version of RHEL8 machines on the floor.

https://docs.conda.io/projects/conda/en/stable/user-guide/tasks/manage-virtual.html#overriding-detected-packages