### PR TITLE
2025-2.1 envs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -172,12 +172,12 @@ jobs:
     strategy:
       matrix:
         repos:
-          - org: "NSLS-II-CSX"
-            repo: "profile_collection"
+          - org: "NSLS2"
+            repo: "smi-profile-collection"
             branch: "main"
             beamline-acronym: "csx"
-          - org: "NSLS-II-TES"
-            repo: "profile_collection"
+          - org: "NSLS2"
+            repo: "tes-profile-collection"
             branch: "main"
             beamline-acronym: "tes"
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -182,7 +182,7 @@ jobs:
           #   beamline-acronym: "smi"
           - org: "NSLS2"
             repo: "tes-profile-collection"
-            branch: "2025-2.0"
+            branch: "main"
             beamline-acronym: "tes"
         python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -176,13 +176,13 @@ jobs:
             repo: "csx-profile-collection"
             branch: "main"
             beamline-acronym: "csx"
-          - org: "NSLS2"
-            repo: "smi-profile-collection"
-            branch: "main"
-            beamline-acronym: "smi"
+          # - org: "NSLS2"
+          #   repo: "smi-profile-collection"
+          #   branch: "main"
+          #   beamline-acronym: "smi"
           - org: "NSLS2"
             repo: "tes-profile-collection"
-            branch: "main"
+            branch: "2025-2.0"
             beamline-acronym: "tes"
         python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -178,7 +178,7 @@ jobs:
             beamline-acronym: "csx"
           - org: "NSLS-II-TES"
             repo: "profile_collection"
-            branch: "2025-2.0"
+            branch: "main"
             beamline-acronym: "tes"
         python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
@@ -257,7 +257,7 @@ jobs:
           echo "Download path: ${{ steps.download.outputs.download-path }}"
           echo "Contents before flattening:"
           ls -la "${{ steps.download.outputs.download-path }}"
-          
+
           # Find all directories except the download path itself
           for dir in "${{ steps.download.outputs.download-path }}"/*; do
             if [ -d "$dir" ]; then
@@ -268,7 +268,7 @@ jobs:
               rm -rf "$dir"
             fi
           done
-          
+
           echo "Contents after flattening:"
           ls -la "${{ steps.download.outputs.download-path }}"
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -173,9 +173,13 @@ jobs:
       matrix:
         repos:
           - org: "NSLS2"
-            repo: "smi-profile-collection"
+            repo: "csx-profile-collection"
             branch: "main"
             beamline-acronym: "csx"
+          - org: "NSLS2"
+            repo: "smi-profile-collection"
+            branch: "main"
+            beamline-acronym: "smi"
           - org: "NSLS2"
             repo: "tes-profile-collection"
             branch: "main"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -90,6 +90,7 @@ dependencies:
   - juliaup
   - jupyter
   - jupyterlab
+  - larixite
   - ldap3
   - legacy-suitcase
   - lixtools
@@ -136,6 +137,7 @@ dependencies:
   - pycryptodome
   - pyepics >=3.4.2
   - pyfai >=2024.5.0
+  - pygithub
   - pyfftw
   - pymatgen >=2024.5.1
   - maggma >=0.66
@@ -147,6 +149,7 @@ dependencies:
   - pypdf2
   - pyqt >=5.15.0
   - pyqtgraph
+  - pyside6
   - pystackreg
   - python-blosc
   - python-graphviz
@@ -232,6 +235,7 @@ dependencies:
   - slack-sdk
   # Beamline-specific packages
   - hklpy  # [linux]
+  - hklpy2
   - hxnfly >=0.0.11
   - kkcalc
   - ppmac

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -19,7 +19,7 @@ dependencies:
   - awkward
   - black
   - blosc-hdf5-plugin
-  - bluesky >=1.13.1rc2
+  - bluesky >=1.14.0
   - bluesky-adaptive >=0.3.1
   - bluesky-kafka >=0.10.0
   - bluesky-live >=0.0.8
@@ -43,7 +43,7 @@ dependencies:
   - dask-jobqueue
   - dask-ml
   - dask-xgboost
-  - databroker >=2.0.0b59
+  - databroker >=2.0.0b62
   - datview
   - dictdiffer
   - diffpy.pdffit2
@@ -109,7 +109,7 @@ dependencies:
   - nodejs
   - nsls2-detector-handlers >=0.0.3
   - nslsii >=0.11.1
-  - numexpr >=2.8.0
+  - numexpr >=2.8.0,!=2.8.4
   - numpy >=1.20
   - nyxtools >=0.0.12
   - oct2py
@@ -181,7 +181,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0b20
+  - tiled >=0.1.0b27
   - toml
   - tomopy >=1.12.2
   - tornado
@@ -205,7 +205,6 @@ dependencies:
   - pip
   - pip:
     - ansiwrap
-    # - bluesky >=1.13.0a3
     # - bloptools >=0.7.0
     - digautoprofiler
     # - gladier

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -149,7 +149,7 @@ dependencies:
   - pypdf2
   - pyqt >=5.15.0
   - pyqtgraph
-  - pyside6
+  # - pyside6
   - pystackreg
   - python-blosc
   - python-graphviz

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -90,6 +90,7 @@ dependencies:
   - juliaup
   - jupyter
   - jupyterlab
+  - larixite
   - ldap3
   - legacy-suitcase
   - lixtools
@@ -136,6 +137,7 @@ dependencies:
   - pycryptodome
   - pyepics >=3.4.2
   - pyfai >=2024.5.0
+  - pygithub
   - pyfftw
   - pymatgen >=2024.5.1
   - maggma >=0.66
@@ -147,6 +149,7 @@ dependencies:
   - pypdf2
   - pyqt >=5.15.0
   - pyqtgraph
+  - pyside6
   - pystackreg
   - python-blosc
   - python-graphviz
@@ -232,6 +235,7 @@ dependencies:
   - slack-sdk
   # Beamline-specific packages
   - hklpy  # [linux]
+  - hklpy2
   - hxnfly >=0.0.11
   - kkcalc
   - ppmac

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -19,7 +19,7 @@ dependencies:
   - awkward
   - black
   - blosc-hdf5-plugin
-  - bluesky >=1.13.1rc2
+  - bluesky >=1.14.0
   - bluesky-adaptive >=0.3.1
   - bluesky-kafka >=0.10.0
   - bluesky-live >=0.0.8
@@ -43,7 +43,7 @@ dependencies:
   - dask-jobqueue
   - dask-ml
   - dask-xgboost
-  - databroker >=2.0.0b59
+  - databroker >=2.0.0b62
   - datview
   - dictdiffer
   - diffpy.pdffit2
@@ -109,7 +109,7 @@ dependencies:
   - nodejs
   - nsls2-detector-handlers >=0.0.3
   - nslsii >=0.11.1
-  - numexpr >=2.8.0
+  - numexpr >=2.8.0,!=2.8.4
   - numpy >=1.20
   - nyxtools >=0.0.12
   - oct2py
@@ -181,7 +181,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0b20
+  - tiled >=0.1.0b27
   - toml
   - tomopy >=1.12.2
   - tornado
@@ -205,7 +205,6 @@ dependencies:
   - pip
   - pip:
     - ansiwrap
-    # - bluesky >=1.13.0a3
     # - bloptools >=0.7.0
     - digautoprofiler
     # - gladier

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -149,7 +149,7 @@ dependencies:
   - pypdf2
   - pyqt >=5.15.0
   - pyqtgraph
-  - pyside6
+  # - pyside6
   - pystackreg
   - python-blosc
   - python-graphviz

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -90,6 +90,7 @@ dependencies:
   - juliaup
   - jupyter
   - jupyterlab
+  - larixite
   - ldap3
   - legacy-suitcase
   - lixtools
@@ -136,6 +137,7 @@ dependencies:
   - pycryptodome
   - pyepics >=3.4.2
   - pyfai >=2024.5.0
+  - pygithub
   - pyfftw
   - pymatgen >=2024.5.1
   - maggma >=0.66
@@ -147,6 +149,7 @@ dependencies:
   - pypdf2
   - pyqt >=5.15.0
   - pyqtgraph
+  - pyside6
   - pystackreg
   - python-blosc
   - python-graphviz
@@ -232,6 +235,7 @@ dependencies:
   - slack-sdk
   # Beamline-specific packages
   - hklpy  # [linux]
+  - hklpy2
   - hxnfly >=0.0.11
   - kkcalc
   - ppmac

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -19,7 +19,7 @@ dependencies:
   - awkward
   - black
   - blosc-hdf5-plugin
-  - bluesky >=1.13.1rc2
+  - bluesky >=1.14.0
   - bluesky-adaptive >=0.3.1
   - bluesky-kafka >=0.10.0
   - bluesky-live >=0.0.8
@@ -43,7 +43,7 @@ dependencies:
   - dask-jobqueue
   - dask-ml
   - dask-xgboost
-  - databroker >=2.0.0b59
+  - databroker >=2.0.0b62
   - datview
   - dictdiffer
   - diffpy.pdffit2
@@ -181,7 +181,7 @@ dependencies:
   - suitcase-tiff >=0.4.0
   - suitcase-utils
   - sympy
-  - tiled >=0.1.0b20
+  - tiled >=0.1.0b27
   - toml
   - tomopy >=1.12.2
   - tornado
@@ -205,7 +205,6 @@ dependencies:
   - pip
   - pip:
     - ansiwrap
-    # - bluesky >=1.13.0a3
     # - bloptools >=0.7.0
     - digautoprofiler
     # - gladier

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -149,7 +149,7 @@ dependencies:
   - pypdf2
   - pyqt >=5.15.0
   - pyqtgraph
-  - pyside6
+  # - pyside6
   - pystackreg
   - python-blosc
   - python-graphviz

--- a/import-tests.py
+++ b/import-tests.py
@@ -37,3 +37,7 @@ print(f"{nslsii.__version__ = }")
 
 import numexpr
 print(f"{numexpr.__version__ = }")
+
+import larch
+import larch.xrd
+print(f"{larch.__version__ = }")


### PR DESCRIPTION
2025-2.1 envs.

Adding a test to capture a missing dependency of `xraylarch` which was discovered while testing at BMM.

Closes #61