### PR TITLE
Implement dynamic version assignment for file names of artifacts

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -57,8 +57,8 @@ jobs:
           export PYTHONVER=$(echo ${{ matrix.python-version }} | sed 's/\.//g')
           echo "PYTHONVER=${PYTHONVER}" >> $GITHUB_ENV
 
-          env_name=$(cat configs/config-py${PYTHONVER}.yml | shyaml get-value env_name)
-          export CONDA_PACK_ENV_NAME=${env_name}
+          # env_name=$(cat configs/config-py${PYTHONVER}.yml | shyaml get-value env_name)
+          export CONDA_PACK_ENV_NAME="${{ github.ref_name }}-py${PYTHONVER}-tiled"
           echo "CONDA_PACK_ENV_NAME=${CONDA_PACK_ENV_NAME}" >> $GITHUB_ENV
 
           export ARTIFACTS_DIR="$HOME/artifacts"
@@ -69,17 +69,17 @@ jobs:
 
           env | sort -u
 
-      - name: Set artifact file name for non-main branch
-        if: github.ref != 'refs/heads/main'
+      - name: Set artifact file name for non-release
+        if: github.event_name != 'release'
         run: |
-          export ARTIFACT_FILE_NAME="test-${{ env.CONDA_PACK_ENV_NAME }}-${{ env.DATETIME_STRING }}"
+          export ARTIFACT_FILE_NAME="${{ env.CONDA_PACK_ENV_NAME }}-${{ env.DATETIME_STRING }}"
           echo "ARTIFACT_FILE_NAME=${ARTIFACT_FILE_NAME}" >> $GITHUB_ENV
 
           export RETENTION_DAYS=14
           echo "RETENTION_DAYS=${RETENTION_DAYS}" >> $GITHUB_ENV
 
-      - name: Set artifact file name for main branch
-        if: github.ref == 'refs/heads/main'
+      - name: Set artifact file name for release
+        if: github.event_name == 'release'
         run: |
           export ARTIFACT_FILE_NAME="${{ env.CONDA_PACK_ENV_NAME }}"
           echo "ARTIFACT_FILE_NAME=${ARTIFACT_FILE_NAME}" >> $GITHUB_ENV

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -40,15 +40,6 @@ jobs:
       - name: Checkout the code
         uses: actions/checkout@v4
 
-      - name: Install Python for YAML CLI tools
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: Install YAML CLI tools
-        run: |
-          python3 -m pip install shyaml
-
       - name: Set env vars
         run: |
           export DATETIME_STRING=$(date +%Y%m%d%H%M%S)
@@ -57,7 +48,6 @@ jobs:
           export PYTHONVER=$(echo ${{ matrix.python-version }} | sed 's/\.//g')
           echo "PYTHONVER=${PYTHONVER}" >> $GITHUB_ENV
 
-          # env_name=$(cat configs/config-py${PYTHONVER}.yml | shyaml get-value env_name)
           export CONDA_PACK_ENV_NAME="${{ github.ref_name }}-py${PYTHONVER}-tiled"
           echo "CONDA_PACK_ENV_NAME=${CONDA_PACK_ENV_NAME}" >> $GITHUB_ENV
 

--- a/configs/config-py310.yml
+++ b/configs/config-py310.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2025-2.0-py310-tiled"
+env_name: "2025-2.1-py310-tiled"
 conda_env_file: "env-py310.yml"
 conda_binary: "mamba"
 python_version: "3.10"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2025-2.0-tiled
+    version: 2025-2.1-tiled
     creators:
       - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py311.yml
+++ b/configs/config-py311.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2025-2.0-py311-tiled"
+env_name: "2025-2.1-py311-tiled"
 conda_env_file: "env-py311.yml"
 conda_binary: "mamba"
 python_version: "3.11"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2025-2.0-tiled
+    version: 2025-2.1-tiled
     creators:
       - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"

--- a/configs/config-py312.yml
+++ b/configs/config-py312.yml
@@ -1,5 +1,5 @@
 docker_image: "quay.io/condaforge/linux-anvil-cos7-x86_64:latest"
-env_name: "2025-2.0-py312-tiled"
+env_name: "2025-2.1-py312-tiled"
 conda_env_file: "env-py312.yml"
 conda_binary: "mamba"
 python_version: "3.12"
@@ -19,7 +19,7 @@ zenodo_metadata:
     title: "NSLS-II collection conda environment"
     upload_type: "software"
     description: "NSLS-II collection conda environment"
-    version: 2025-2.0-tiled
+    version: 2025-2.1-tiled
     creators:
       - name: Rakitin, Max
         affiliation: "Brookhaven National Laboratory"

--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -1,4 +1,4 @@
-name: 2025-2.0-py310-tiled
+name: 2025-2.1-py310-tiled
 channels:
   - conda-forge
 dependencies:

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -1,4 +1,4 @@
-name: 2025-2.0-py311-tiled
+name: 2025-2.1-py311-tiled
 channels:
   - conda-forge
 dependencies:

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -1,4 +1,4 @@
-name: 2025-2.0-py312-tiled
+name: 2025-2.1-py312-tiled
 channels:
   - conda-forge
 dependencies:


### PR DESCRIPTION
This implementation will hopefully prevent accidental uploads of the artifacts with the non-updated version in the file names, like it was done in https://zenodo.org/records/15376322.

### GHA artifacts

The generated artifact names were tested via https://github.com/NSLS2/nsls2-collection-tiled/actions/runs/14938115891:
![image](https://github.com/user-attachments/assets/9c204588-8bda-43cc-8331-bea95f3a80bd)

### Directory tree

The directory tree after unpacking of one of the zip artifacts:

```bash
$ tree dynamic-version-py310-tiled-20250509173421
dynamic-version-py310-tiled-20250509173421
├── dynamic-version-py310-tiled-md5sum.txt
├── dynamic-version-py310-tiled-sha256sum.txt
├── dynamic-version-py310-tiled.tar.gz
└── dynamic-version-py310-tiled.yml

1 directory, 4 files
```