### PR TITLE
Add Zenodo downloading script

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,17 +10,27 @@ on:
 
 jobs:
   pre-commit:
+    name: Format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-    - uses: pre-commit/action@v3.0.1
-      with:
-        extra_args: --all-files --show-diff-on-failure
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - uses: astral-sh/setup-uv@v6
+
+      - uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --hook-stage manual --all-files
 
   generate_conda_packd_envs:
     name: "Generate: py${{ matrix.python-version }}"
     runs-on: ubuntu-latest
+    needs: pre-commit
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -9,6 +9,15 @@ on:
   workflow_dispatch:
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+    - uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --all-files --show-diff-on-failure
+
   generate_conda_packd_envs:
     name: "Generate: py${{ matrix.python-version }}"
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,18 +8,9 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 
-  - repo: local
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.11.9"
     hooks:
       - id: ruff
-        name: lint with ruff
-        language: system
-        entry: ruff check --force-exclude --fix
-        types: [python]
-        require_serial: true
-
+        args: ["--fix", "--show-fixes"]
       - id: ruff-format
-        name: format with ruff
-        language: system
-        entry: ruff format --force-exclude
-        types: [python]
-        require_serial: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,24 @@ default_language_version:
     python: python3
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
     - id: check-yaml
     - id: end-of-file-fixer
     - id: trailing-whitespace
+
+  - repo: local
+    hooks:
+      - id: ruff
+        name: lint with ruff
+        language: system
+        entry: ruff check --force-exclude --fix
+        types: [python]
+        require_serial: true
+
+      - id: ruff-format
+        name: format with ruff
+        language: system
+        entry: ruff format --force-exclude
+        types: [python]
+        require_serial: true

--- a/import-tests.py
+++ b/import-tests.py
@@ -1,4 +1,15 @@
 import argparse
+import sys
+import event_model
+import bluesky
+import ophyd
+import ophyd_async
+import databroker
+import tiled
+import nslsii
+import numexpr
+import larch
+import larch.xrd
 
 parser = argparse.ArgumentParser(description="Test import of various Python packages.")
 parser.add_argument(
@@ -8,36 +19,19 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-import sys
 print(f"{sys.executable = }\n{sys.version = }\n{sys.version_info = }")
 
-version_str = '.'.join([str(x) for x in sys.version_info[0:2]])
-assert args.python_version == version_str, f"Python version mismatch: {args.python_version} != {version_str}"
+version_str = ".".join([str(x) for x in sys.version_info[0:2]])
+assert args.python_version == version_str, (
+    f"Python version mismatch: {args.python_version} != {version_str}"
+)
 
-import event_model
 print(f"{event_model.__version__ = }")
-
-import bluesky
 print(f"{bluesky.__version__ = }")
-
-import ophyd
 print(f"{ophyd.__version__ = }")
-
-import ophyd_async
 print(f"{ophyd_async.__version__ = }")
-
-import databroker
 print(f"{databroker.__version__ = }")
-
-import tiled
 print(f"{tiled.__version__ = }")
-
-import nslsii
 print(f"{nslsii.__version__ = }")
-
-import numexpr
 print(f"{numexpr.__version__ = }")
-
-import larch
-import larch.xrd
 print(f"{larch.__version__ = }")

--- a/zenodo_download.py
+++ b/zenodo_download.py
@@ -1,0 +1,159 @@
+import argparse
+import os
+import re
+import requests
+import tqdm
+
+BASE_URL = "https://zenodo.org/api"
+
+
+def download_from_zenodo(
+    conceptrecid,
+    version=None,
+    files_to_download=None,
+    exclude_files=None,
+    token=None,
+    dry_run=False,
+):
+    """Download files from Zenodo.
+    Args:
+        conceptrecid (str): Zenodo concept record ID to identify the latest deposition to download from, e.g. 4057062.
+        version (str, optional): Version of the deposition to download from (e.g., 2025-2.0). If None, the latest version will be used.
+        files_to_download (list, optional): List of file names or regex patterns to download. If None, all files will be downloaded.
+        exclude_files (list, optional): List of file names or regex patterns to exclude from download. If None, no files will be excluded.
+        token (str): The Zenodo API token for authentication.
+        dry_run (bool): If True, only print the files that would be downloaded without actually downloading them.
+    """
+    if token is None:
+        token = ""
+
+    headers = {"Authorization": f"Bearer {token}"}
+
+    concept_rec = requests.get(
+        f"{BASE_URL}/records/{conceptrecid}",
+        headers=headers,
+    )
+
+    versions = requests.get(
+        concept_rec.json()["links"]["versions"],
+        headers=headers,
+    )
+
+    if version is not None:
+        # Find the version with the specified version string
+        for ver in versions.json()["hits"]["hits"]:
+            if ver["metadata"]["version"] == version:
+                record_id = ver["id"]
+                break
+        else:
+            raise ValueError(f"Version '{version}' not found in the deposition.")
+        rec = requests.get(
+            f"{BASE_URL}/records/{record_id}",
+            headers=headers,
+        )
+    else:
+        rec = concept_rec
+        record_id = rec.json()["id"]  # Latest version
+
+    files = requests.get(
+        f"{BASE_URL}/records/{record_id}/files",
+        headers=headers,
+    )
+
+    files_dict = {file["key"]: file for file in files.json()["entries"]}
+    files_names = sorted(files_dict.keys())
+
+    print(f"Zenodo deposition: {record_id}")
+    print(f"Title: {rec.json()['title']}")
+    print("Files:")
+    for file in files_names:
+        print(f"  - {file}")
+
+    downloaded = []
+
+    for file_name in files_names:
+        entry = files_dict[file_name]
+        if files_to_download is not None:
+            if not any(re.search(file, file_name) for file in files_to_download):
+                print(f"Skipping file: {file_name}")
+                continue
+
+        if exclude_files is not None:
+            if any(re.search(exclude, file_name) for exclude in exclude_files):
+                print(f"Excluding file: {file_name}")
+                continue
+
+        if not dry_run:
+            with requests.get(entry["links"]["content"], stream=True) as r:
+                r.raise_for_status()
+                print(f"Downloading file: {file_name}")
+                total_size = int(entry.get("size", 0))
+
+                with tqdm.tqdm(
+                    total=total_size, unit="B", unit_scale=True
+                ) as progress_bar:
+                    with open(file_name, "wb") as f:
+                        for chunk in r.iter_content(chunk_size=8 * 1024):
+                            progress_bar.update(len(chunk))
+                            f.write(chunk)
+                        downloaded.append(file_name)
+        else:
+            print(f"Would download file: {file_name}")
+            downloaded.append(file_name)
+
+    if not dry_run:
+        print(f"\nDownloaded {len(downloaded)} file(s):")
+    else:
+        print(f"\nWould download {len(downloaded)} file(s):")
+    for file in downloaded:
+        print(f"  - {file}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download files from Zenodo")
+    parser.add_argument(
+        "-c",
+        "--conceptrecid",
+        required=True,
+        help="Zenodo concept record ID to identify the latest deposition to download from, e.g. 4057062",
+    )
+    parser.add_argument(
+        "-v",
+        "--version",
+        help="Version of the deposition to download from (e.g., 2025-2.0). If not provided, the latest version will be used",
+    )
+    parser.add_argument(
+        "-f",
+        "--files",
+        nargs="*",
+        help="List of file names or regex patterns to download. If not provided, all files will be downloaded",
+    )
+    parser.add_argument(
+        "-e",
+        "--exclude-files",
+        nargs="*",
+        help="List of file names or regex patterns to exclude from download. If not provided, no files will be excluded",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Only print the files that would be downloaded without actually downloading them",
+    )
+
+    args = parser.parse_args()
+
+    # Get token from environment
+    token = os.environ.get("ZENODO_TOKEN", "")
+
+    download_from_zenodo(
+        conceptrecid=args.conceptrecid,
+        version=args.version,
+        files_to_download=args.files,
+        exclude_files=args.exclude_files,
+        token=token,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/zenodo_upload.py
+++ b/zenodo_upload.py
@@ -60,9 +60,7 @@ def upload_files(bucket_url, files, token):
         print_now(ret_commit.status_code, ret_commit.text)
 
 
-def create_new_version(
-    conceptrecid=None, version=None, extra_files=None, token=None
-):
+def create_new_version(conceptrecid=None, version=None, extra_files=None, token=None):
     rec = requests.get(
         f"{BASE_URL}/records/{conceptrecid}/versions/latest",
         headers={"Authorization": f"Bearer {token}"},
@@ -79,9 +77,9 @@ def create_new_version(
     notes_urls = [
         f"https://github.com/NSLS2/nsls2-collection-tiled/releases/tag/{version}"
     ]
-    notes_urls_strs = "<br>\n".join([f'<a href="{url}">Release notes</a>'
-                                     if url else ""
-                                     for url in notes_urls])
+    notes_urls_strs = "<br>\n".join(
+        [f'<a href="{url}">Release notes</a>' if url else "" for url in notes_urls]
+    )
 
     unpack_instructions = """
 Unpacking instructions:
@@ -115,12 +113,7 @@ conda-unpack
             "additional_descriptions": [
                 {
                     "description": unpack_instructions,
-                    "type": {
-                        "id": "notes",
-                        "title": {
-                            "en": "Unpacking instructions"
-                        }
-                    },
+                    "type": {"id": "notes", "title": {"en": "Unpacking instructions"}},
                 },
             ],
             "creators": [
@@ -130,15 +123,19 @@ conda-unpack
                         "given_name": "Max",
                         "family_name": "Rakitin",
                         "type": "personal",
-                        "identifiers": [{
-                            "scheme": "orcid",
-                            "identifier": "0000-0003-3685-852X",
-                        }],
+                        "identifiers": [
+                            {
+                                "scheme": "orcid",
+                                "identifier": "0000-0003-3685-852X",
+                            }
+                        ],
                     },
-                    "affiliations": [{
-                        "id": "01q47ea17",
-                        "name": "NSLS-II, Brookhaven National Laboratory",
-                    }],
+                    "affiliations": [
+                        {
+                            "id": "01q47ea17",
+                            "name": "NSLS-II, Brookhaven National Laboratory",
+                        }
+                    ],
                 },
                 {
                     "person_or_org": {
@@ -146,15 +143,19 @@ conda-unpack
                         "given_name": "Bischof",
                         "family_name": "Garrett",
                         "type": "personal",
-                        "identifiers": [{
-                            "scheme": "orcid",
-                            "identifier": "0000-0001-9351-274X",
-                        }],
+                        "identifiers": [
+                            {
+                                "scheme": "orcid",
+                                "identifier": "0000-0001-9351-274X",
+                            }
+                        ],
                     },
-                    "affiliations": [{
-                        "id": "01q47ea17",
-                        "name": "NSLS-II, Brookhaven National Laboratory",
-                    }],
+                    "affiliations": [
+                        {
+                            "id": "01q47ea17",
+                            "name": "NSLS-II, Brookhaven National Laboratory",
+                        }
+                    ],
                 },
                 {
                     "person_or_org": {
@@ -162,15 +163,19 @@ conda-unpack
                         "given_name": "Jun",
                         "family_name": "Aishima",
                         "type": "personal",
-                        "identifiers": [{
-                            "scheme": "orcid",
-                            "identifier": "0000-0003-4710-2461",
-                        }],
+                        "identifiers": [
+                            {
+                                "scheme": "orcid",
+                                "identifier": "0000-0003-4710-2461",
+                            }
+                        ],
                     },
-                    "affiliations": [{
-                        "id": "01q47ea17",
-                        "name": "NSLS-II, Brookhaven National Laboratory",
-                    }],
+                    "affiliations": [
+                        {
+                            "id": "01q47ea17",
+                            "name": "NSLS-II, Brookhaven National Laboratory",
+                        }
+                    ],
                 },
             ],
         }
@@ -233,47 +238,56 @@ def get_files_from_artifacts(artifacts_dir):
     """Get all files from the artifacts directory and prepare them for upload."""
     files = {}
     artifacts_path = Path(artifacts_dir)
-    
+
     print(f"Looking for files in: {artifacts_path.absolute()}")
     if not artifacts_path.exists():
         print(f"ERROR: Directory {artifacts_path} does not exist!")
         return files
-        
+
     print("Directory contents:")
     for item in artifacts_path.iterdir():
         print(f"  - {item.name} ({'file' if item.is_file() else 'directory'})")
-    
+
     # Find all files in the artifacts directory
     for file_path in artifacts_path.glob("*"):
         if file_path.is_file():
             # Determine the access mode based on file extension
-            if file_path.suffix == '.gz':
-                mode = 'rb'
+            if file_path.suffix == ".gz":
+                mode = "rb"
             else:
-                mode = 'r'
+                mode = "r"
             files[str(file_path)] = mode
-            
+
     return files
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Upload files to Zenodo')
-    parser.add_argument('--conceptrecid', required=True, help='Zenodo concept record ID')
-    parser.add_argument('--version', required=True, help='Version string for the upload')
-    parser.add_argument('--artifacts-dir', required=True, help='Directory containing the files to upload')
-    parser.add_argument('--token', help='Zenodo API token (can also be provided via ZENODO_TOKEN env var)')
-    parser.add_argument('--dry-run', action='store_true', help='Print what would be done without making any HTTP requests')
-    
+    parser = argparse.ArgumentParser(description="Upload files to Zenodo")
+    parser.add_argument(
+        "--conceptrecid", required=True, help="Zenodo concept record ID"
+    )
+    parser.add_argument(
+        "--version", required=True, help="Version string for the upload"
+    )
+    parser.add_argument(
+        "--artifacts-dir",
+        required=True,
+        help="Directory containing the files to upload",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would be done without making any HTTP requests",
+    )
+
     args = parser.parse_args()
-    
-    # Get token from args or environment
-    token = args.token or os.environ.get('ZENODO_TOKEN')
-    if not token and not args.dry_run:
-        raise ValueError("Zenodo token must be provided either via --token or ZENODO_TOKEN environment variable")
-    
+
+    # Get token from environment
+    token = os.environ.get("ZENODO_TOKEN", "")
+
     # Get files from artifacts directory
     files = get_files_from_artifacts(args.artifacts_dir)
-    
+
     if args.dry_run:
         print("DRY RUN: Would upload the following files:")
         for file in files:
@@ -281,13 +295,13 @@ def main():
         print(f"  - Version: {args.version}")
         print(f"  - Concept record ID: {args.conceptrecid}")
         return
-    
+
     # Create new version and upload files
     resp = create_new_version(
         conceptrecid=args.conceptrecid,
         version=args.version,
         token=token,
-        extra_files=files
+        extra_files=files,
     )
     pprint.pprint(resp)
 

--- a/zenodo_upload.py
+++ b/zenodo_upload.py
@@ -289,6 +289,7 @@ def main():
     if not token and not args.dry_run:
         print_now("Error: ZENODO_TOKEN environment variable is not set or is empty.")
         sys.exit(1)
+
     # Get files from artifacts directory
     files = get_files_from_artifacts(args.artifacts_dir)
 

--- a/zenodo_upload.py
+++ b/zenodo_upload.py
@@ -285,6 +285,10 @@ def main():
     # Get token from environment
     token = os.environ.get("ZENODO_TOKEN", "")
 
+    # Ensure token is not empty during non-dry-run executions
+    if not token and not args.dry_run:
+        print_now("Error: ZENODO_TOKEN environment variable is not set or is empty.")
+        sys.exit(1)
     # Get files from artifacts directory
     files = get_files_from_artifacts(args.artifacts_dir)
 


### PR DESCRIPTION
This PR also touches the Zenodo uploading script to remove the CLI option for passing a token (not good as it can be seen in the list of processes via `htop` or `ps`).

I also updated the `pre-commit` config and added the respective step to the CI config, therefore, there are a few changes in other files.

# Examples

## Download all files from the latest record

**Note**: `4057062` is the concept record ID, which will resolve to the latest deposition by default.

```bash
❯ python zenodo_download.py -c 4057062
Zenodo deposition: 15377276
Title: NSLS-II collection conda environment 2025-2.1rc2 with Python 3.10, 3.11, and 3.12
Files:
  - 2025-2.1rc2-py310-tiled-md5sum.txt
  - 2025-2.1rc2-py310-tiled-sha256sum.txt
  - 2025-2.1rc2-py310-tiled.tar.gz
  - 2025-2.1rc2-py310-tiled.yml.txt
  - 2025-2.1rc2-py311-tiled-md5sum.txt
  - 2025-2.1rc2-py311-tiled-sha256sum.txt
  - 2025-2.1rc2-py311-tiled.tar.gz
  - 2025-2.1rc2-py311-tiled.yml.txt
  - 2025-2.1rc2-py312-tiled-md5sum.txt
  - 2025-2.1rc2-py312-tiled-sha256sum.txt
  - 2025-2.1rc2-py312-tiled.tar.gz
  - 2025-2.1rc2-py312-tiled.yml.txt
Downloading file: 2025-2.1rc2-py310-tiled-md5sum.txt
100%|██████████████████████████████████████████████████████████████████████████████████| 93.0/93.0 [00:00<00:00, 146kB/s]
Downloading file: 2025-2.1rc2-py310-tiled-sha256sum.txt
100%|███████████████████████████████████████████████████████████████████████████████████| 130/130 [00:00<00:00, 87.1kB/s]
Downloading file: 2025-2.1rc2-py310-tiled.tar.gz
100%|███████████████████████████████████████████████████████████████████████████████| 2.53G/2.53G [07:44<00:00, 5.45MB/s]
Downloading file: 2025-2.1rc2-py310-tiled.yml.txt
100%|████████████████████████████████████████████████████████████████████████████████| 39.4k/39.4k [00:00<00:00, 357kB/s]
Downloading file: 2025-2.1rc2-py311-tiled-md5sum.txt
100%|█████████████████████████████████████████████████████████████████████████████████| 93.0/93.0 [00:00<00:00, 67.9kB/s]
Downloading file: 2025-2.1rc2-py311-tiled-sha256sum.txt
100%|███████████████████████████████████████████████████████████████████████████████████| 130/130 [00:00<00:00, 2.51kB/s]
Downloading file: 2025-2.1rc2-py311-tiled.tar.gz
100%|███████████████████████████████████████████████████████████████████████████████| 2.62G/2.62G [07:01<00:00, 6.22MB/s]
Downloading file: 2025-2.1rc2-py311-tiled.yml.txt
100%|████████████████████████████████████████████████████████████████████████████████| 39.5k/39.5k [00:00<00:00, 407kB/s]
Downloading file: 2025-2.1rc2-py312-tiled-md5sum.txt
100%|█████████████████████████████████████████████████████████████████████████████████| 93.0/93.0 [00:00<00:00, 2.08kB/s]
Downloading file: 2025-2.1rc2-py312-tiled-sha256sum.txt
100%|███████████████████████████████████████████████████████████████████████████████████| 130/130 [00:00<00:00, 16.6kB/s]
Downloading file: 2025-2.1rc2-py312-tiled.tar.gz
100%|███████████████████████████████████████████████████████████████████████████████| 2.61G/2.61G [06:48<00:00, 6.39MB/s]
Downloading file: 2025-2.1rc2-py312-tiled.yml.txt
100%|████████████████████████████████████████████████████████████████████████████████| 39.5k/39.5k [00:00<00:00, 386kB/s]

Downloaded 12 file(s):
  - 2025-2.1rc2-py310-tiled-md5sum.txt
  - 2025-2.1rc2-py310-tiled-sha256sum.txt
  - 2025-2.1rc2-py310-tiled.tar.gz
  - 2025-2.1rc2-py310-tiled.yml.txt
  - 2025-2.1rc2-py311-tiled-md5sum.txt
  - 2025-2.1rc2-py311-tiled-sha256sum.txt
  - 2025-2.1rc2-py311-tiled.tar.gz
  - 2025-2.1rc2-py311-tiled.yml.txt
  - 2025-2.1rc2-py312-tiled-md5sum.txt
  - 2025-2.1rc2-py312-tiled-sha256sum.txt
  - 2025-2.1rc2-py312-tiled.tar.gz
  - 2025-2.1rc2-py312-tiled.yml.txt
```

## Download only `*.yml` files for the 2025-1.0 deposition

```bash
❯ python zenodo_download.py -c 4057062 -v 2025-1.0 -f ".*\.yml"
Zenodo deposition: 14862443
Title: NSLS-II collection conda environment 2025-1.0 with Python 3.10, 3.11, and 3.12
Files:
  - 2025-1.0-py310-tiled-md5sum.txt
  - 2025-1.0-py310-tiled-sha256sum.txt
  - 2025-1.0-py310-tiled.tar.gz
  - 2025-1.0-py310-tiled.yml.txt
  - 2025-1.0-py311-tiled-md5sum.txt
  - 2025-1.0-py311-tiled-sha256sum.txt
  - 2025-1.0-py311-tiled.tar.gz
  - 2025-1.0-py311-tiled.yml.txt
  - 2025-1.0-py312-tiled-md5sum.txt
  - 2025-1.0-py312-tiled-sha256sum.txt
  - 2025-1.0-py312-tiled.tar.gz
  - 2025-1.0-py312-tiled.yml.txt
Skipping file: 2025-1.0-py310-tiled-md5sum.txt
Skipping file: 2025-1.0-py310-tiled-sha256sum.txt
Skipping file: 2025-1.0-py310-tiled.tar.gz
Downloading file: 2025-1.0-py310-tiled.yml.txt
100%|████████████████████████████████████████████████████████████████████████████████| 38.9k/38.9k [00:00<00:00, 481kB/s]
Skipping file: 2025-1.0-py311-tiled-md5sum.txt
Skipping file: 2025-1.0-py311-tiled-sha256sum.txt
Skipping file: 2025-1.0-py311-tiled.tar.gz
Downloading file: 2025-1.0-py311-tiled.yml.txt
100%|████████████████████████████████████████████████████████████████████████████████| 39.0k/39.0k [00:00<00:00, 419kB/s]
Skipping file: 2025-1.0-py312-tiled-md5sum.txt
Skipping file: 2025-1.0-py312-tiled-sha256sum.txt
Skipping file: 2025-1.0-py312-tiled.tar.gz
Downloading file: 2025-1.0-py312-tiled.yml.txt
100%|████████████████████████████████████████████████████████████████████████████████| 38.9k/38.9k [00:00<00:00, 184kB/s]

Downloaded 3 file(s):
  - 2025-1.0-py310-tiled.yml.txt
  - 2025-1.0-py311-tiled.yml.txt
  - 2025-1.0-py312-tiled.yml.txt
```