### PR TITLE
Declare bluesky-tiled-plugins dep

### DIFF
--- a/envs/env-py310.yml
+++ b/envs/env-py310.yml
@@ -25,6 +25,7 @@ dependencies:
   - bluesky-live >=0.0.8
   - bluesky-queueserver >=0.0.19
   - bluesky-queueserver-api >=0.0.10
+  - bluesky-tiled-plugins >=2.0.0b64
   - bluesky-widgets >=0.0.15
   - bokeh
   - boto3

--- a/envs/env-py311.yml
+++ b/envs/env-py311.yml
@@ -25,6 +25,7 @@ dependencies:
   - bluesky-live >=0.0.8
   - bluesky-queueserver >=0.0.19
   - bluesky-queueserver-api >=0.0.10
+  - bluesky-tiled-plugins >=2.0.0b64
   - bluesky-widgets >=0.0.15
   - bokeh
   - boto3

--- a/envs/env-py312.yml
+++ b/envs/env-py312.yml
@@ -25,6 +25,7 @@ dependencies:
   - bluesky-live >=0.0.8
   - bluesky-queueserver >=0.0.19
   - bluesky-queueserver-api >=0.0.10
+  - bluesky-tiled-plugins >=2.0.0b64
   - bluesky-widgets >=0.0.15
   - bokeh
   - boto3


### PR DESCRIPTION
We were getting this via databroker, but it may be helpful to declare the dependency and the minimum version directly.